### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,6 +3,9 @@ name: Build Windows Executable
 on:
   workflow_dispatch:  # Manual trigger only
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/molmdl/quickice/security/code-scanning/1](https://github.com/molmdl/quickice/security/code-scanning/1)

To fix this, explicitly define minimal `GITHUB_TOKEN` permissions for the workflow or for the `build` job. The workflow needs only to read repository contents (for `actions/checkout`) and does not push commits, modify issues, or interact with PRs, so `contents: read` is sufficient. Setting this at the workflow root applies to all jobs and documents the intended permissions.

The best fix with no functional change is:

- Add a `permissions:` block at the top level of `.github/workflows/build-windows.yml`, just under the `on:` section.
- Set `contents: read` so the token can read the repository for checkout, but cannot write to it.

Concretely, in `.github/workflows/build-windows.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (after line 5). No additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
